### PR TITLE
bug: provide informative message when no tests are found rt-list

### DIFF
--- a/rt-cli/src/main.rs
+++ b/rt-cli/src/main.rs
@@ -78,6 +78,10 @@ fn main() -> anyhow::Result<()> {
             };
             let globs = glob_with(&owned_string, options).expect("Failed to read glob pattern");
 
+            // Collect globs into a vector of strings
+            // if there is an error it will be displayed as
+            // a string
+            // this lets us count how many paths were found
             let tests = globs
                 .map(|g| match g {
                     Ok(p) => p.display().to_string(),
@@ -85,13 +89,19 @@ fn main() -> anyhow::Result<()> {
                 })
                 .collect::<Vec<_>>();
 
+            // if no files were found we use `eprintln!()` to write to stderr
+            // otherwise, we print each file
             if tests.is_empty() {
                 eprintln!("❗️ No tests found.")
             } else {
+                // here we check to see if there is 1 or more values so that
+                // we can use a plural if needed
                 let n = tests.len();
                 let test_or_tests = if n > 1 { "tests" } else { "test" };
                 println!("Found {} {test_or_tests}", tests.len());
-                tests.iter().for_each(|t| println!("📌 {t}"));
+                // note that we must use `for_each()` instead of `.map()`
+                // when we want to iterate but not produce values from the iteration
+                tests.iter().for_each(|t| println!("{t}"));
             }
         }
         Subcommands::Versions(_) => {


### PR DESCRIPTION
This PR closes #5 by adding a message when no tests are found. 

I also changed the variant names for the enum to make it easier to follow. 

I was also playing around with emojis here. Can remove :) 