### PR TITLE
Fail well when not inside a package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "wasi"

--- a/rt-cli/src/main.rs
+++ b/rt-cli/src/main.rs
@@ -2,6 +2,7 @@ extern crate glob;
 use argh::FromArgs;
 use glob::glob_with;
 use glob::MatchOptions;
+use std::path::Path;
 use std::usize;
 
 mod rscript;
@@ -59,8 +60,13 @@ fn main() -> anyhow::Result<()> {
     let args: Rt = argh::from_env();
     match args.subcommand {
         Subcommands::Dir(cmd) => {
-            let devtools_call = format!("devtools::test('{}')", cmd.dir);
-            run_rscript(&devtools_call)?;
+            let pkg_exists = Path::new(&format!("{}/DESCRIPTION", &cmd.dir)).exists();
+            if !pkg_exists {
+                eprintln!("Error: not an R package")
+            } else {
+                let devtools_call = format!("devtools::test('{}')", cmd.dir);
+                run_rscript(&devtools_call)?;
+            }
         }
         Subcommands::File(cmd) => {
             let testthat_call =

--- a/rt-cli/src/main.rs
+++ b/rt-cli/src/main.rs
@@ -69,9 +69,30 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Subcommands::File(cmd) => {
-            let testthat_call =
-                format!("devtools::load_all(); testthat::test_file('{}')", cmd.file);
-            run_rscript(&testthat_call)?;
+            // let file = format!("{}", &cmd.file);
+            let file = cmd.file.to_string();
+            let mut ancestors = Path::new(&file).ancestors();
+            let parent = ancestors.next();
+            println!("{:?}", &parent);
+            let grandparent = ancestors.next();
+            println!("{:?}", &grandparent);
+            let grandgrandparent = ancestors.next();
+            println!("{:?}", &grandgrandparent);
+            let grandgrandgrandparent = ancestors.next();
+            println!("{:?}", &grandgrandgrandparent);
+            // let grandparent = ancestors.skip(2).next().unwrap();
+            println!(
+                "{}",
+                &grandgrandgrandparent.unwrap().join("DESCRIPTION").display()
+            );
+            let pkg_exists = grandgrandgrandparent.unwrap().join("DESCRIPTION").exists();
+            if !pkg_exists {
+                eprintln!("Error: not an R package")
+            } else {
+                let testthat_call =
+                    format!("devtools::load_all(); testthat::test_file('{}')", cmd.file);
+                run_rscript(&testthat_call)?;
+            }
         }
         Subcommands::List(cmd) => {
             let mut owned_string: String = "/tests/testthat/test-*.R".to_owned();


### PR DESCRIPTION
fix #5 

@JosiahParry here's the work. 

I think `dir` is all set, but maybe not?

For `file` it's not clear when to stop going up to a parent dir. Maybe there's a class/fun that makes to use here? Perhaps we only go up two (three if self is the first) levels from a file and stop there since that's the typical testthat setup at least?